### PR TITLE
Improve customer maintenance sampling and add throughput output

### DIFF
--- a/simu/model/Customer.java
+++ b/simu/model/Customer.java
@@ -49,7 +49,12 @@ public class Customer {
         this.needInspection = rand.nextDouble() < needInspectionPercentage;
         this.passedInspection = !(rand.nextDouble() < inspectionFailRate); //set default
 
-        int maintenanceNeeded = Math.max(0, (int)Math.round(maintenanceGenerator.sample()));
+        double sample;
+        do {
+            sample = maintenanceGenerator.sample();
+        } while (Math.round(sample) < 1);
+
+        int maintenanceNeeded = (int)Math.round(sample);
 
         for (int i = 0; i < maintenanceNeeded; i++) {
             mt.add(getRandomMaintenanceType());
@@ -178,6 +183,10 @@ public class Customer {
         double mean = sum / totalServed;
         System.out.println("Current mean of the customer service times " + mean);
         System.out.println(" Total number of customer served : " + totalServed);
+    }
+
+    public static int getTotalServed() {
+        return totalServed;
     }
 }
 

--- a/simu/model/MyEngine.java
+++ b/simu/model/MyEngine.java
@@ -88,6 +88,6 @@ public class MyEngine extends Engine {
     @Override
     protected void results() {
        System.out.println("Simulation ended at " + Clock.getInstance().getClock());
-       System.out.println("Results ... are currently missing");
+       System.out.printf("%nResults:%nCustomer throughput: %f customer(s) per hour.%n", (Customer.getTotalServed() / Clock.getInstance().getClock()) * 60);
     }
 }

--- a/simu/model/bEvent/BEvent.java
+++ b/simu/model/bEvent/BEvent.java
@@ -90,8 +90,6 @@ public class BEvent {
                 a.setRemovalTime(Clock.getInstance().getClock());
                 a.reportResults();
                 break;
-
-
             case DEP_TIRE_END:
                 a = servicePoints[2].removeQueue();
                 a.setRemovalTime(Clock.getInstance().getClock());


### PR DESCRIPTION
Updated Customer to ensure at least one maintenance is always needed by resampling if the rounded sample is less than 1. Added a static getter for totalServed in Customer. MyEngine now prints customer throughput at the end of the simulation. Minor cleanup in BEvent.