### PR TITLE
Add simulator setup view and controller

### DIFF
--- a/src/main/java/Launcher.java
+++ b/src/main/java/Launcher.java
@@ -1,15 +1,11 @@
 import javafx.application.Application;
-import simu.view.StepperView;
+import simu.view.SetupView;
 
 
 public class Launcher {
 
-    void launchApp() {
-        Application.launch(StepperView.class);
-    }
-
     public static void main(String[] args) {
-        new Launcher().launchApp();
+        Application.launch(SetupView.class);
     }
 }
 

--- a/src/main/java/simu/controller/SimulatorSetupViewController.java
+++ b/src/main/java/simu/controller/SimulatorSetupViewController.java
@@ -1,0 +1,117 @@
+package simu.controller;
+
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.Slider;
+import javafx.scene.control.TextField;
+import javafx.scene.input.MouseEvent;
+import javafx.stage.Stage;
+import simu.view.StepperView;
+
+import java.io.IOException;
+
+public class SimulatorSetupViewController {
+
+    @FXML
+    private Button applySimulationTime;
+
+    @FXML
+    private Button arrivalApply;
+
+    @FXML
+    private TextField arrivalMean;
+
+    @FXML
+    private TextField arrivalVariance;
+
+    @FXML
+    private Label delayLabel;
+
+    @FXML
+    private Button increaseSpeed;
+
+    @FXML
+    private Slider inspectionFailRate;
+
+    @FXML
+    private TextField meanService;
+
+    @FXML
+    private Button runProgram;
+
+    @FXML
+    private Button serviceApply;
+
+    @FXML
+    private TextField serviceVariance;
+
+    @FXML
+    private Button setDefault;
+
+    @FXML
+    private Button setSave;
+
+    @FXML
+    private Button slowSpeed;
+
+    @FXML
+    private TextField totalTime;
+
+    private StepperView stepperView;
+
+    @FXML
+    void onApplySimulationTime(ActionEvent event) {
+
+    }
+
+    @FXML
+    void onArrivalApply(ActionEvent event) {
+
+    }
+
+    @FXML
+    void onDecreaseSpeed(ActionEvent event) {
+
+    }
+
+    @FXML
+    void onIncreaseSpeed(ActionEvent event) {
+
+    }
+
+    @FXML
+    void onInspectionFailRate(MouseEvent event) {
+
+    }
+
+    @FXML
+    void onRunProgram(ActionEvent event) {
+        stepperView = new StepperView();
+        try {
+            Stage stage = stepperView.init();
+            runProgram.setDisable(true);
+            stage.showAndWait();
+            runProgram.setDisable(false);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @FXML
+    void onServiceApply(ActionEvent event) {
+
+    }
+
+    @FXML
+    void onSetDefault(ActionEvent event) {
+
+    }
+
+    @FXML
+    void onSetSave(ActionEvent event) {
+
+    }
+
+}

--- a/src/main/java/simu/view/SetupView.java
+++ b/src/main/java/simu/view/SetupView.java
@@ -1,0 +1,20 @@
+package simu.view;
+
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+
+public class SetupView extends Application {
+    @Override
+    public void start(Stage stage) throws IOException {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("/view/simulator_setup.fxml"));
+        Parent parent = loader.load();
+        Scene scene = new Scene(parent);
+        stage.setScene(scene);
+        stage.show();
+    }
+}

--- a/src/main/java/simu/view/StepperView.java
+++ b/src/main/java/simu/view/StepperView.java
@@ -9,12 +9,18 @@ import simu.controller.StepperViewController;
 
 import java.io.IOException;
 
-public class StepperView extends Application {
+// don't worry about the 1 related problem, it is from Unit Test
+public class StepperView {
 
     private StepperViewController controller;
 
-    @Override
-    public void start(Stage stage) throws IOException {
+    /**
+     * Create and display stepper view
+     * @Note you can pass parameters here if needed
+     * @throws IOException
+     */
+    public Stage init() throws IOException {
+        Stage stage = new Stage();
         FXMLLoader loader = new FXMLLoader(getClass().getResource("/view/stepper.fxml"));
         Parent root = loader.load();
         controller = loader.getController();
@@ -22,7 +28,11 @@ public class StepperView extends Application {
 
         Scene scene = new Scene(root);
         stage.setScene(scene);
-        stage.show();
+        return stage;
+    }
+
+    public StepperViewController getController() {
+        return controller;
     }
 }
 

--- a/src/main/resources/view/simulator_setup.fxml
+++ b/src/main/resources/view/simulator_setup.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="350.0" prefWidth="500.0" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1" fx:controller="simu.controller.VisualizeTestViewController">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="350.0" prefWidth="500.0" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1" fx:controller="simu.controller.SimulatorSetupViewController">
    <children>
       <VBox layoutX="209.0" layoutY="89.0" prefHeight="200.0" prefWidth="100.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
          <children>


### PR DESCRIPTION
This pull request introduces a new setup screen for the simulator and refactors how the main application launches. The main changes include adding a new `SetupView` as the application's entry point, implementing its controller, and updating the FXML configuration and related view logic.

**Application Startup Refactor:**

* The application now launches with `SetupView` instead of `StepperView`, making the setup screen the main entry point (`Launcher.java`, `SetupView.java`). [[1]](diffhunk://#diff-87ec10369cbab7cc6476dd4712d8c19a300f1dd2b76466969f5667236273d745L2-R8) [[2]](diffhunk://#diff-3bdce1374d00ac67c458e36a8e627d0049c89ab1ae4fbbad9b529bee27227ff1R1-R20)

**Setup Screen Implementation:**

* Added a new controller `SimulatorSetupViewController` with FXML bindings and event handlers for the setup screen's UI controls (`SimulatorSetupViewController.java`).
* Updated the FXML file to use `SimulatorSetupViewController` as its controller, replacing the previous controller (`simulator_setup.fxml`).

**Stepper View Refactor:**

* Refactored `StepperView` from a subclass of `Application` to a regular class with an `init()` method, allowing it to be launched from the setup screen instead of directly as the main application (`StepperView.java`).

<sub>Description generated by GitHub Copilot.</sub>