### PR TITLE
create FieldController

### DIFF
--- a/src/main/java/controller/FieldController.java
+++ b/src/main/java/controller/FieldController.java
@@ -1,0 +1,28 @@
+package controller;
+
+import eduni.distributions.Normal;
+import simu.model.MyEngine;
+
+public class FieldController {
+
+    private MyEngine myEngine;
+
+    public void setArrivalTime(String mean, String variance) {
+        myEngine.setArrivalContinuousGenerator(new Normal(Double.parseDouble(mean), Double.parseDouble(variance)));
+    }
+
+    public void totalSimulationTime(String mean, String variance) {
+        myEngine.setSimulationTime(Double.parseDouble(mean));
+        myEngine.setServiceContinuousGenerator(new Normal(Double.parseDouble(mean), Double.parseDouble(variance)));
+
+    }
+
+    public void setInspecionFailRate(double inspecionFailRate) {
+        myEngine.setInspectionFailRate(inspecionFailRate);
+    }
+
+
+    public void init(MyEngine myEngine) {
+        this.myEngine = myEngine;
+    }
+}

--- a/src/main/java/simu/model/MyEngine.java
+++ b/src/main/java/simu/model/MyEngine.java
@@ -28,6 +28,11 @@ public class MyEngine extends Engine {
     public static final boolean FIXEDARRIVALTIMES = false;
     public static final boolean FXIEDSERVICETIMES = false;
     public ContinuousGenerator cGenerator;
+    private ContinuousGenerator arrivalContinuousGenerator;
+    private ContinuousGenerator serviceContinuousGenerator;
+    private double inspectionFailRate;
+
+
 
 
     /**
@@ -66,7 +71,7 @@ public class MyEngine extends Engine {
         servicePoints[5] = new InspectionServicePoint(cGenerator, eventList);
 
         // Create arrival process (customers arriving at the system)
-        arrivalProcess = new ArrivalProcess(cGenerator, eventList, EventType.ARR_CUSTOMER_SERVICE);
+        arrivalProcess = new ArrivalProcess(arrivalContinuousGenerator, eventList, EventType.ARR_CUSTOMER_SERVICE);
     }
 
     @Override
@@ -76,7 +81,7 @@ public class MyEngine extends Engine {
 
     @Override
     protected void runEvent(Event t) {  // B phase events
-        BEvent.runBEvent(servicePoints, arrivalProcess, t, vc);
+        BEvent.runBEvent(servicePoints, arrivalProcess, t, vc, serviceContinuousGenerator, inspectionFailRate);
     }
 
     @Override
@@ -86,6 +91,18 @@ public class MyEngine extends Engine {
              p.beginService();
           }
        }
+    }
+
+    public void setArrivalContinuousGenerator(ContinuousGenerator arrivalContinuousGenerator) {
+        this.arrivalContinuousGenerator = arrivalContinuousGenerator;
+    }
+
+    public void setServiceContinuousGenerator(ContinuousGenerator serviceContinuousGenerator) {
+        this.serviceContinuousGenerator = serviceContinuousGenerator;
+    }
+
+    public void setInspectionFailRate(double inspectionFailRate) {
+        this.inspectionFailRate = inspectionFailRate;
     }
 
     @Override

--- a/src/main/java/simu/model/bEvent/BEvent.java
+++ b/src/main/java/simu/model/bEvent/BEvent.java
@@ -22,7 +22,9 @@ public class BEvent {
             ServicePoint[] servicePoints,
             ArrivalProcess arrivalProcess,
             Event event,
-            VisualizeController vc
+            VisualizeController vc,
+            ContinuousGenerator maintenanceGenerator,
+            double inspectionFailRate
     ) {
         // B event code here
 
@@ -42,8 +44,8 @@ public class BEvent {
 
 		switch ((EventType)event.getType()) {
             case ARR_CUSTOMER_SERVICE:
-                ContinuousGenerator maintenanceGenerator = new Normal(2, 1);
-                a = new Customer(maintenanceGenerator, 0.6, 0.1);
+                maintenanceGenerator = new Normal(2, 1);
+                a = new Customer(maintenanceGenerator, 0.6, inspectionFailRate);
                 servicePoints[0].addQueue(a);
 				arrivalProcess.generateNextEvent();
                 break;


### PR DESCRIPTION
This pull request introduces a new `FieldController` class to manage simulation parameters and refactors the simulation engine (`MyEngine`) to allow dynamic configuration of arrival and service time distributions, as well as the inspection fail rate. The changes improve modularity and make it easier to adjust simulation parameters from outside the engine.

**Controller and Configuration Improvements:**

* Added a new `FieldController` class that provides methods to set arrival time, total simulation time, and inspection fail rate by interacting with the `MyEngine` instance. (`src/main/java/controller/FieldController.java`)
* Added setter methods in `MyEngine` for configuring the arrival time generator, service time generator, and inspection fail rate, enabling external control of these parameters. (`src/main/java/simu/model/MyEngine.java`)

**Simulation Engine Refactoring:**

* Modified `MyEngine` to use configurable `arrivalContinuousGenerator` and `serviceContinuousGenerator` instead of a fixed generator, allowing for more flexible simulation setups. (`src/main/java/simu/model/MyEngine.java`) [[1]](diffhunk://#diff-132c956263ad657adf948107c167829e67093bb4c4d9ad64bd853f983a3feea5R31-R35) [[2]](diffhunk://#diff-132c956263ad657adf948107c167829e67093bb4c4d9ad64bd853f983a3feea5L69-R74)
* Updated the call to `BEvent.runBEvent` to pass the service time generator and inspection fail rate, so that these parameters can be used dynamically during event processing. (`src/main/java/simu/model/MyEngine.java`) [[1]](diffhunk://#diff-132c956263ad657adf948107c167829e67093bb4c4d9ad64bd853f983a3feea5L79-R84) [[2]](diffhunk://#diff-05207ca6b5610a527217011c5169b1d08c70c58895c3c84977427b362383bd00L25-R27)

**Simulation Logic Adjustment:**

* Adjusted the `BEvent.runBEvent` method signature to accept the new parameters, and modified the logic for creating `Customer` instances to use the dynamic inspection fail rate. (`src/main/java/simu/model/bEvent/BEvent.java`) [[1]](diffhunk://#diff-05207ca6b5610a527217011c5169b1d08c70c58895c3c84977427b362383bd00L25-R27) [[2]](diffhunk://#diff-05207ca6b5610a527217011c5169b1d08c70c58895c3c84977427b362383bd00L45-R48)